### PR TITLE
dm: hide S3 external ID from physical lightning source dir

### DIFF
--- a/dm/loader/lightning.go
+++ b/dm/loader/lightning.go
@@ -16,6 +16,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -127,8 +128,33 @@ func MakeGlobalConfig(cfg *config.SubTaskConfig) *lcfg.GlobalConfig {
 		lightningCfg.TikvImporter.SortedKVDir = cfg.SortingDirPhysical
 	}
 	lightningCfg.Mydumper.SourceDir = cfg.Dir
+	if cfg.LoaderConfig.ImportMode == config.LoadModePhysical {
+		lightningCfg.Mydumper.SourceDir = stripS3ExternalIDFromSourceDir(lightningCfg.Mydumper.SourceDir)
+	}
 	lightningCfg.App.Config.File = "" // make lightning not init logger, see more in https://github.com/pingcap/tidb/pull/29291
 	return lightningCfg
+}
+
+func stripS3ExternalIDFromSourceDir(sourceDir string) string {
+	u, err := url.Parse(sourceDir)
+	if err != nil || !strings.EqualFold(u.Scheme, "s3") || u.RawQuery == "" {
+		return sourceDir
+	}
+
+	values := u.Query()
+	changed := false
+	for key := range values {
+		if strings.EqualFold(key, "external-id") || strings.EqualFold(key, "external_id") {
+			values.Del(key)
+			changed = true
+		}
+	}
+	if !changed {
+		return sourceDir
+	}
+
+	u.RawQuery = values.Encode()
+	return u.String()
 }
 
 // Type implements Unit.Type.

--- a/dm/loader/lightning_test.go
+++ b/dm/loader/lightning_test.go
@@ -14,6 +14,7 @@
 package loader
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -42,6 +43,46 @@ func TestSetLightningConfig(t *testing.T) {
 	cfg, err := l.getLightningConfig()
 	require.NoError(t, err)
 	require.Equal(t, stCfg.LoaderConfig.PoolSize, cfg.App.RegionConcurrency)
+}
+
+func TestMakeGlobalConfigStripsS3ExternalIDForPhysicalImport(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1&force_path_style=0"
+	stCfg := &config.SubTaskConfig{
+		LoaderConfig: config.LoaderConfig{
+			Dir:                sourceDir,
+			ImportMode:         config.LoadModePhysical,
+			SortingDirPhysical: "/tmp/sorted-kv",
+		},
+	}
+
+	lightningCfg := MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendLocal, lightningCfg.TikvImporter.Backend)
+	require.Equal(t, sourceDir, stCfg.LoaderConfig.Dir)
+	require.Equal(t, sourceDir, stCfg.Dir)
+
+	u, err := url.Parse(lightningCfg.Mydumper.SourceDir)
+	require.NoError(t, err)
+	require.Empty(t, u.Query().Get("external-id"))
+	require.Equal(t, "arn:aws:iam::123456789012:role/import", u.Query().Get("role-arn"))
+	require.Equal(t, "0", u.Query().Get("force_path_style"))
+}
+
+func TestMakeGlobalConfigKeepsS3ExternalIDForLogicalImport(t *testing.T) {
+	t.Parallel()
+
+	sourceDir := "s3://bucket/path?role-arn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2Fimport&external-id=cluster-1"
+	stCfg := &config.SubTaskConfig{
+		LoaderConfig: config.LoaderConfig{
+			Dir:        sourceDir,
+			ImportMode: config.LoadModeLogical,
+		},
+	}
+
+	lightningCfg := MakeGlobalConfig(stCfg)
+	require.Equal(t, lcfg.BackendTiDB, lightningCfg.TikvImporter.Backend)
+	require.Equal(t, sourceDir, lightningCfg.Mydumper.SourceDir)
 }
 
 func TestConvertLightningError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Keep DM physical import storage access compatible with S3 roles that require an external ID.
- Strip the S3 `external-id` query parameter only from Lightning `Mydumper.SourceDir` in physical import mode.
- Leave the original DM data directory and external storage unchanged so dumpling and Lightning can still access the dump files through the assumed role.

## Why

Premium DM physical import writes dump files to shared-pool S3 through a keyspace role. Dumpling needs `external-id` when assuming that role, but TiDB NextGen security enhanced mode rejects an explicit S3 external ID in `IMPORT INTO` and injects the keyspace name as the external ID itself. See pingcap/tidb#68231 for the TiDB-side behavior.

Without separating these two views of the same S3 location, the job fails in one of two ways: keeping `external-id` reaches TiDB planner error 8132, while removing it makes dumpling fail to assume the S3 role.

## How

- `MakeGlobalConfig` now sanitizes only the Lightning source directory for physical import mode.
- The sanitizer applies only to S3 URIs and removes `external-id` / `external_id` query keys case-insensitively.
- Other query parameters such as `role-arn` remain intact.
- Logical import mode keeps the source directory unchanged.

## Testing

- [x] `go test ./dm/loader -run 'TestMakeGlobalConfigStripsS3ExternalIDForPhysicalImport|TestMakeGlobalConfigKeepsS3ExternalIDForLogicalImport'`

## Risks and Reviewer Focus

- Review whether any Lightning checkpoint comparison relies on the raw query string for physical import. This patch intentionally changes only the Lightning config source dir, while keeping DM's original `cfg.Dir` and `ExtStorage` for actual storage access.
- The change is scoped to S3 physical imports; other storage backends and logical imports are unchanged.
